### PR TITLE
Render typst PDFs in CI (and switch freeze to auto)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,11 +59,13 @@ jobs:
           install-quarto: 'false'
 
       - name: Cache Typst packages
+        # Bump the v<N> prefix to force a cache refresh (e.g. if a qmd starts
+        # using an @preview import that isn't covered by the hashed paths).
         uses: actions/cache@v4
         with:
           path: ~/.cache/typst/packages
-          key: typst-packages-${{ hashFiles('_extensions/**/*.typ', '_quarto.yml') }}
-          restore-keys: typst-packages-
+          key: typst-packages-v1-${{ hashFiles('_extensions/**/*.typ', '_quarto.yml') }}
+          restore-keys: typst-packages-v1-
 
       - name: Render site
         run: quarto render

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,10 +58,15 @@ jobs:
           cache-version: 1
           install-quarto: 'false'
 
-      - name: Render site (skip typst to avoid CI stall)
-        run: |
-          find lectures -name "*.qmd" -exec sed -i '/^  ochre-typst: default$/d' {} +
-          quarto render
+      - name: Cache Typst packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/typst/packages
+          key: typst-packages-${{ hashFiles('_extensions/**/*.typ', '_quarto.yml') }}
+          restore-keys: typst-packages-
+
+      - name: Render site
+        run: quarto render
 
       - name: Publish to GitHub Pages
         uses: quarto-dev/quarto-actions/publish@v2

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,7 +10,7 @@ project:
 editor:
   render-on-save: true
 execute:
-  freeze: true # always use cached results; render locally before pushing
+  freeze: auto # re-render only when source changes; CI installs R so it can re-execute
 
 website:
   page-navigation: true


### PR DESCRIPTION
## Problem

Deployed PDFs (e.g. `lectures/L07/lecture-07.pdf` on gh-pages) have been silently going stale even when GitHub Actions reports success. Root cause: the workflow strips `ochre-typst: default` from every `.qmd` before rendering, so CI never regenerates PDFs. Instead, `_quarto.yml` declares `resources: - "lectures/**/*.pdf"`, which copies whatever PDFs happen to be committed in source to `_site/` and then gh-pages. A contributor who edits a `.qmd` without also re-rendering the PDF locally and committing it sees their HTML update correctly while the PDF stays frozen.

Example: commit `ce25985` updated `lecture-07.qmd` + `_freeze/` but did not touch `lecture-07.pdf`. gh-pages HTML reflects the text edits; the deployed PDF dates from `ac9fa75` (March).

Separately, `freeze: true` in `_quarto.yml` prevented CI from ever re-executing code chunks, even after PR #12 added R to the runner. The comment on that line said *"render locally before pushing"* — an implicit contract that was easy to violate.

## Changes

**`.github/workflows/publish.yml`**
- Remove the `sed -i '/^  ochre-typst: default$/d'` line — CI now renders HTML and PDF.
- Add an `actions/cache@v4` step for `~/.cache/typst/packages` keyed by `_extensions/**/*.typ` hash, so typst-package downloads don't stall first-run CI (this was the original reason the sed workaround existed).
- Rename the render step to just "Render site".

**`_quarto.yml`**
- `execute.freeze: true` → `execute.freeze: auto`. With R installed on CI (since PR #12), there's no reason to block re-execution. `auto` re-runs only when source changes, so `_freeze/` stays useful as a cache but is no longer a hard requirement.

## Verified against docs

- `quarto-dev/quarto-actions/publish@v2` with `target: gh-pages` and `render: "false"` is the documented configuration for skipping re-render during publish (README confirms).
- `freeze: auto` semantics confirmed verbatim from Quarto docs: *"re-render only when source changes"*.
- Typst runtime cache at `~/.cache/typst/packages` matches standard typst CLI behaviour; the same cache step is in use in [ENVX2001-resources](https://github.com/ENVX-resources/ENVX2001-resources/blob/main/.github/workflows/publish.yml).

## Not in this PR (follow-ups)

- `_quarto.yml` still declares `resources: - "lectures/**/*.pdf"`. Once CI PDF generation is confirmed working, this line should be removed and the committed source PDFs (`lectures/L0X/*.pdf`) deleted — they'll be superseded by CI-generated ones.
- Consider switching from dynamic `renv::dependencies()` discovery to `r-lib/actions/setup-renv@v2`, which would pin R package versions exactly to `renv.lock` instead of picking up the latest CRAN versions. More reproducible, but a behavioural change worth a separate discussion.

## Test plan

- [ ] Merge-queue trigger: push the branch and manually run via `gh workflow run publish.yml --ref ci/render-typst-pdfs` — this WILL publish to gh-pages from the branch, so only do this when ready to overwrite the live site, or wait until after merge.
- [ ] Safer: review the workflow diff below, merge, then watch the first post-merge run.
- [ ] After the first successful run, compare a deployed PDF's `lastModified` to the triggering commit's timestamp to confirm CI generated it.
- [ ] Watch for font/typst package resolution errors in the render step — the `fonts/` directory is bundled (per CLAUDE.md) so this should work, but worth verifying.

## Risks

- **First CI run will be slower** (~5-10 min extra) while the typst package cache warms. Subsequent runs should be fast.
- If the `ochre-typst` extension has a font or typst package the cache key doesn't cover, render may fail. Fix is typically an `apt-get` or updating the cache key.
- If PDF generation fails for any reason on CI, the `resources:` fallback to committed PDFs kicks in — so existing PDFs continue to serve until this is cleaned up in the follow-up PR.