### PR TITLE
Fix CI render hang: install ragg and align ochre-typst with ENVX2001

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,9 @@ jobs:
             pkgs <- unique(renv::dependencies(quiet = TRUE)$Package)
             pkgs <- setdiff(pkgs, c("R", rownames(installed.packages(priority = "base"))))
             # Suggests-tier packages loaded at runtime (e.g. by performance::check_model)
-            soft_extras <- c("see", "patchwork", "qqplotr")
+            # and packages referenced only as YAML strings (e.g. dev: "ragg_png" in
+            # lectures/_metadata.yml) which renv::dependencies() cannot discover.
+            soft_extras <- c("see", "patchwork", "qqplotr", "ragg", "systemfonts")
             pkgs <- unique(c(pkgs, soft_extras))
             github_map <- c(
               renderthis = "gadenbuie/renderthis"

--- a/lectures/L01/lecture-01a.qmd
+++ b/lectures/L01/lecture-01a.qmd
@@ -3,7 +3,8 @@ title: Lecture 01a -- Welcome to ENVX1002
 author: Liana Pozza
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 

--- a/lectures/L01/lecture-01b.qmd
+++ b/lectures/L01/lecture-01b.qmd
@@ -3,7 +3,8 @@ title: Lecture 01b -- Reproducible science
 author: Januar Harianto
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 # format: revealjs
 # fontsize: 16pt
 ---

--- a/lectures/L02/lecture-02.qmd
+++ b/lectures/L02/lecture-02.qmd
@@ -7,7 +7,8 @@ lightbox: true
 format:
   ochre-revealjs:
     slide-number: true
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 

--- a/lectures/L03/lecture-03.qmd
+++ b/lectures/L03/lecture-03.qmd
@@ -3,7 +3,8 @@ title: "Lecture 03: Exploring and visualising data"
 author: Januar Harianto
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ```{r setup, include=FALSE}

--- a/lectures/L04/lecture-04.qmd
+++ b/lectures/L04/lecture-04.qmd
@@ -3,7 +3,8 @@ title: "Lecture 04 -- The central limit theorem"
 author: Januar Harianto
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ```{r setup, include=FALSE}

--- a/lectures/L05/lecture-05.qmd
+++ b/lectures/L05/lecture-05.qmd
@@ -3,7 +3,8 @@ title: Topic 5 -- Introduction to hypothesis testing
 author: Floris van Ogtrop
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ## Important Notice

--- a/lectures/L06/lecture-06.qmd
+++ b/lectures/L06/lecture-06.qmd
@@ -3,7 +3,8 @@ title: Topic 6 -- Two-sample *t*-tests
 author: Floris van Ogtrop
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 # Testing differences in means

--- a/lectures/L07/lecture-07.qmd
+++ b/lectures/L07/lecture-07.qmd
@@ -3,7 +3,8 @@ title: Topic 7 -- Non-parametric tests
 author: Floris van Ogtrop
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ```{r setup}

--- a/lectures/L08/lecture-08.qmd
+++ b/lectures/L08/lecture-08.qmd
@@ -3,7 +3,8 @@ title: Topic 8 -- A modern approach to hypothesis testing with infer
 author: Floris van Ogtrop
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ## Announcement

--- a/lectures/L09/lecture-09.qmd
+++ b/lectures/L09/lecture-09.qmd
@@ -3,7 +3,8 @@ title: Topic 9 -- Describing relationships
 author: Si Yang Han
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ## About me

--- a/lectures/L10/lecture-10.qmd
+++ b/lectures/L10/lecture-10.qmd
@@ -3,7 +3,8 @@ title: Topic 10 -- Simple Linear Regression
 author: Si Yang Han
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 scrollable: true
 ---
 

--- a/lectures/L11/abalone-quiz.qmd
+++ b/lectures/L11/abalone-quiz.qmd
@@ -3,7 +3,8 @@ title: "L11 MLR -- Abalone Quiz"
 author: Si Yang Han
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 ---
 
 ```{r setup, include=FALSE}

--- a/lectures/L11/lecture-11.qmd
+++ b/lectures/L11/lecture-11.qmd
@@ -3,7 +3,8 @@ title: Topic 11 -- Multiple Linear Regression
 author: Si Yang Han
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 scrollable: true
 prefer-html: true
 ---

--- a/lectures/L12/lecture-12.qmd
+++ b/lectures/L12/lecture-12.qmd
@@ -3,7 +3,8 @@ title: Topic 12 -- Nonlinear regression
 author: Si Yang Han
 format:
   ochre-revealjs: default
-  ochre-typst: default
+  ochre-typst:
+    fig-format: png
 scrollable: true
 ---
 ## Module overview


### PR DESCRIPTION
## Context

PR #13 merged the port of ENVX2001's CI pattern (real typst render + `freeze: auto` + typst package cache). The first post-merge run (ID `24782113299`) got as far as `Cache Typst packages` and then hung indefinitely in the `Render site` step — I cancelled after ~24h with no progress signal. `freeze: true` had been hiding two latent gaps. This PR fixes both.

## Root cause

### 1. `ragg` is never installed on CI

`lectures/_metadata.yml:15` sets `knitr.opts_chunk.dev: "ragg_png"` globally. The workflow's package discovery uses `renv::dependencies()`, which scans R code for `library()` / `::` / `require()` references. Because `ragg` is referenced **only** as a YAML string, the scanner misses it. The last successful post-PR-#12 run's log confirms this — 45 packages discovered, `ragg` not among them.

Under the old `freeze: true`, CI never re-executed any chunks — it consumed the pre-baked PNG figures from `_freeze/` (rendered locally, where `ragg` **is** installed). Missing `ragg` was invisible.

Under `freeze: auto`, CI re-executes when source changes. knitr reads `dev = "ragg_png"`, tries to initialise a device from a package that isn't there, and hangs instead of cleanly erroring.

### 2. `ochre-typst: default` triggers a PNG→PDF conversion path

ENVX2001-resources renders `ochre-typst` successfully on `ubuntu-latest` with the byte-for-byte identical Ochre extension. The difference: every lecture in ENVX2001 sets `fig-format: png` on its `ochre-typst` block. Quarto's default `fig-format` for typst is `pdf`, which means knitr-produced PNG figures go through a conversion path (needs `rsvg-convert`/`magick`) before embedding. Forcing PNG mirrors the known-working pattern.

## Changes

**`.github/workflows/publish.yml`**
- Add `ragg` and `systemfonts` to the `soft_extras` manual package list.
- Comment explaining the category of package this list catches (YAML-string-only references).

**14 lecture qmd headers** (`lectures/L*/*.qmd`)
- `ochre-typst: default` → `ochre-typst:\n    fig-format: png`

No changes to `_quarto.yml` or `_metadata.yml` — the `dev: "ragg_png"` directive stays (it gives better systemfonts support for custom fonts in ggplots); we just make sure its dependency actually installs.

## Evidence cited in this PR

- Run log of `24649473626` (PR #12 first run) enumerating the 45 discovered packages — `ragg` absent.
- `_extensions/ochre/_extension.yml` is byte-identical between ENVX2001-resources and this repo — proves it's not an extension or font issue.
- `https://github.com/ENVX-resources/ENVX2001-resources/blob/main/lectures/L07/Lecture-07.qmd` lines 7-10 show the `ochre-typst: { fig-format: png }` pattern in a repo with passing CI.

## Test plan

- [ ] Merge and let the `push` trigger fire once.
- [ ] Watch the `Install R packages` step for `ragg` + `systemfonts` appearing in the resolved set.
- [ ] Watch `Render site` progress past the 13:58:49-UTC wall where the previous run hung.
- [ ] Confirm `_site/lectures/L*/lecture-*.pdf` are generated by the render step.
- [ ] Compare a deployed PDF's modified-time vs the merge commit — must be fresh.

## Not in this PR (follow-ups)

- Remove `resources: "lectures/**/*.pdf"` from `_quarto.yml`.
- `git rm lectures/L*/lecture-*.pdf` (currently serving as fallback while this PR proves CI generation works).
- Dedupe `scrollable: true` / `slide-number: true` from L02/L10/L11/L12 headers (`lectures/_metadata.yml` already sets them).
- Remove `prefer-html: true` from L11 (probably stale).
- Update `CLAUDE.md`: drop the stale *"fonts bundled in `fonts/`"* claim.