### PR TITLE
ci: install Chrome Headless Shell to fix render hang on ubuntu-24.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,22 @@ jobs:
           key: typst-packages-v1-${{ hashFiles('_extensions/**/*.typ', '_quarto.yml') }}
           restore-keys: typst-packages-v1-
 
+      - name: Install Chrome Headless Shell
+        # Quarto rasterises mermaid/dot diagrams to PNG via Chrome for non-HTML
+        # outputs (typst PDF here). On ubuntu-24.04 the default Chrome's
+        # user-namespace sandbox is blocked by an AppArmor profile, causing
+        # silent indefinite hangs in the Chrome zygote. Headless Shell is a
+        # standalone sandbox-free binary built for this; it's Quarto's own
+        # recommendation as of 2026-04-14.
+        # See https://quarto.org/docs/blog/posts/2026-04-14-chrome-headless-shell/
+        run: quarto install chrome-headless-shell --no-prompt
+
       - name: Render site
-        run: quarto render
+        env:
+          # Verbose Quarto logs so any future render hang is diagnosable in
+          # one run rather than across days. See quarto-cli#12977.
+          QUARTO_LOG_LEVEL: DEBUG
+        run: quarto render --verbose
 
       - name: Publish to GitHub Pages
         uses: quarto-dev/quarto-actions/publish@v2


### PR DESCRIPTION
## Why

Recent CI runs have been intermittently hanging at the Render step with this signature:

```
[execProcess] which google-chrome
[CHROMIUM] Found Chromium on OS known location
[CHROMIUM] Path: /usr/bin/google-chrome
[hang for 1+ hour, runner unresponsive]
```

After a real investigation (rather than the guesswork that mistakenly blamed PR #15 yesterday and prompted the force-push reset back to \`851993d\` to clean history), the root cause is:

- Quarto rasterises **mermaid diagrams** (and graphviz/dot) to PNG via Chrome for non-HTML outputs. \`lectures/L01/lecture-01a.qmd:103\` has a mermaid sequence diagram → triggers the Chrome path during typst PDF render.
- **\`ubuntu-24.04\` ships an AppArmor profile** that blocks Chrome's user-namespace sandbox. When the sandbox fails to establish, Chrome's zygote hangs indefinitely on syscalls instead of erroring. Documented by Puppeteer's [troubleshooting page](https://pptr.dev/troubleshooting).
- **\`chromote\`'s \`--no-sandbox\` workaround does not help** because Quarto's diagram path **bypasses chromote** and invokes Chrome directly without sandbox-disable flags. (This is a real gap — confirmed via reading both projects' source.)

## What

One workflow step + DEBUG logging.

\`\`\`yaml
- name: Install Chrome Headless Shell
  run: quarto install chrome-headless-shell --no-prompt

- name: Render site
  env:
    QUARTO_LOG_LEVEL: DEBUG
  run: quarto render --verbose
\`\`\`

**Chrome Headless Shell** is a standalone, sandbox-free Chrome binary built specifically for headless rendering. It's not subject to the AppArmor profile that blocks the user-namespace sandbox. This is **Quarto's own recommendation** for this exact class of failure, published 2026-04-14: https://quarto.org/docs/blog/posts/2026-04-14-chrome-headless-shell/

The \`QUARTO_LOG_LEVEL: DEBUG\` env + \`--verbose\` is what surfaced the \`[CHROMIUM]\` lines that pinpointed the root cause. Keeping it on means the next mystery hang (if any) is diagnosable from a single run rather than a multi-day investigation.

## Risks

- First post-merge run will be ~30s slower (Chrome Headless Shell install). Subsequent runs unaffected — \`quarto install\` is idempotent and the binary is small.
- DEBUG logging makes the run logs much longer. Useful, but if it ever becomes noisy enough to obscure errors, can be downgraded to \`INFO\`.
- This PR does **not** include the cleanup work that was in PR #15 (drop \`resources:\`/\`post-render:\`/source-PDFs/lecture header dedupe). That cleanup was always correct but got blamed wrongly for the hang. After this PR is verified green, a follow-up PR will re-do that work cleanly. Same for the \`.DS_Store\` cleanup that was in PR #17.

## Test plan

- [ ] Merge → watch the post-push run.
- [ ] Confirm \`Install Chrome Headless Shell\` step succeeds.
- [ ] Confirm \`Render site\` completes (with verbose logs) and produces 14 typst PDFs in \`_site/\`.
- [ ] Confirm gh-pages publish step pushes fresh PDFs.
- [ ] Re-trigger via \`workflow_dispatch\` once or twice to verify the previously-intermittent failure is now consistently green.